### PR TITLE
Correction de code pour le marqueur de modèle `the_title()`

### DIFF
--- a/template-parts/full-post.php
+++ b/template-parts/full-post.php
@@ -12,7 +12,7 @@
         </a>
       </div>
       <div class="fr-mr-5w fr-mt-5w">
-        <h1 class="fr-h1"><?php echo the_title() ?></h1>
+        <h1 class="fr-h1"><?php the_title() ?></h1>
       </div>
       <div class="fr-mr-5w fr-mt-5w">
         <span style="font-size:14px;color:#929292;">Th&eacute;matique(s)&nbsp;:</span>


### PR DESCRIPTION
Par défaut, le marqueur de modèle `the_title()` affiche directement le contenu du post_title, il n'est pas nécessaire ni souhaitable d'ajouter un `echo` lorsque cette fonction est utilisée.<> Documentation : https://developer.wordpress.org/reference/functions/the_title/